### PR TITLE
CloudWatch Logsパース処理の重複削除

### DIFF
--- a/lambda/error-notification/src/domain/__init__.py
+++ b/lambda/error-notification/src/domain/__init__.py
@@ -10,11 +10,13 @@ from .exceptions import (
 )
 from .line_message import LineImageMessage, LineMessage, LineTextMessage
 from .line_notifier_interface import ILineNotifier
+from .parsed_cloudwatch_logs_data import ParsedCloudWatchLogsData
 from .s3_client_interface import IS3Client
 
 __all__ = [
     # Models
     "ErrorLogRecord",
+    "ParsedCloudWatchLogsData",
     "LineTextMessage",
     "LineImageMessage",
     "LineMessage",

--- a/lambda/error-notification/src/domain/cloudwatch_logs_parser_interface.py
+++ b/lambda/error-notification/src/domain/cloudwatch_logs_parser_interface.py
@@ -4,21 +4,21 @@ from abc import ABC, abstractmethod
 
 from aws_lambda_powertools.utilities.data_classes import CloudWatchLogsEvent
 
-from .error_log_record import ErrorLogRecord
+from .parsed_cloudwatch_logs_data import ParsedCloudWatchLogsData
 
 
 class ICloudWatchLogsParser(ABC):
     """CloudWatch Logs パーサーインターフェース"""
 
     @abstractmethod
-    def parse(self, event: CloudWatchLogsEvent) -> list[ErrorLogRecord]:
+    def parse(self, event: CloudWatchLogsEvent) -> ParsedCloudWatchLogsData:
         """CloudWatch Logs イベントをパース
 
         Args:
             event: AWS Lambda Powertools の CloudWatchLogsEvent
 
         Returns:
-            list[ErrorLogRecord]: パースされたエラーログレコードリスト
+            ParsedCloudWatchLogsData: パース済みデータ (エラーレコード + メタデータ)
 
         Raises:
             CloudWatchLogsParseError: パース失敗時

--- a/lambda/error-notification/src/domain/parsed_cloudwatch_logs_data.py
+++ b/lambda/error-notification/src/domain/parsed_cloudwatch_logs_data.py
@@ -1,0 +1,17 @@
+"""パース済み CloudWatch Logs データモデル"""
+
+from pydantic import BaseModel
+
+from .error_log_record import ErrorLogRecord
+
+
+class ParsedCloudWatchLogsData(BaseModel):
+    """パース済み CloudWatch Logs データ
+
+    CloudWatchLogsParser.parse() の戻り値として使用し、
+    エラーレコードとメタデータをまとめて返す
+    """
+
+    error_records: list[ErrorLogRecord]
+    log_group: str
+    log_stream: str

--- a/lambda/error-notification/src/presentation/error_notification_handler.py
+++ b/lambda/error-notification/src/presentation/error_notification_handler.py
@@ -42,12 +42,10 @@ def main(
         )
 
     # CloudWatch Logs イベントパース
-    error_records = parser.parse(event)
-
-    # log_group と log_stream を取得
-    decoded_data = event.parse_logs_data()
-    log_group = decoded_data.log_group
-    log_stream = decoded_data.log_stream
+    parsed_data = parser.parse(event)
+    error_records = parsed_data.error_records
+    log_group = parsed_data.log_group
+    log_stream = parsed_data.log_stream
 
     # エラー通知サービス実行
     message_formatter = MessageFormatter()


### PR DESCRIPTION
Issue: #80 

PR#83指摘対応: event.parse_logs_data()の2重呼び出しを解消

- ParsedCloudWatchLogsDataドメインモデル追加
- パーサーの戻り値を拡張してメタデータも返却
- ハンドラーの重複パース処理を削除

パフォーマンス改善とコード品質向上を実現。

Fixes: #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to error log parsing structure to enhance data organization and maintainability.
  * Updated parser implementation to encapsulate log metadata with error records in a unified container.
  * Updated corresponding tests to validate the restructured parsing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->