### PR TITLE
ログイン認証情報を SecretStr 化

### DIFF
--- a/lambda/web-scraping/src/config/scraping_parameters.py
+++ b/lambda/web-scraping/src/config/scraping_parameters.py
@@ -1,15 +1,17 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, SecretStr
 
 
 class ScrapingParameters(BaseModel):
     """Web スクレイピング接続情報の設定 DTO
 
     SSM Parameter Store の値と環境変数（user_agent）から構築される。
+    認証情報フィールドは SecretStr で保持し、平文化は明示的な
+    .get_secret_value() 呼び出しに限定する。
     """
 
-    login_user_id: str
-    login_password: str
-    login_birthdate: str
+    login_user_id: SecretStr
+    login_password: SecretStr
+    login_birthdate: SecretStr
 
     start_url: str
     user_agent: str

--- a/lambda/web-scraping/src/infrastructure/selenium_scraper.py
+++ b/lambda/web-scraping/src/infrastructure/selenium_scraper.py
@@ -80,9 +80,9 @@ class SeleniumScraper(IScraper):
             input_user_id = self.driver.find_element(By.NAME, "userId")
             input_password = self.driver.find_element(By.NAME, "password")
             input_birthdate = self.driver.find_element(By.NAME, "birthDate")
-            input_user_id.send_keys(self.user_id)
-            input_password.send_keys(self.password)
-            input_birthdate.send_keys(self.birthdate)
+            input_user_id.send_keys(self.user_id.get_secret_value())
+            input_password.send_keys(self.password.get_secret_value())
+            input_birthdate.send_keys(self.birthdate.get_secret_value())
 
             btn_login = self.driver.find_element(By.ID, "btnLogin")
             btn_login.submit()

--- a/lambda/web-scraping/tests/config/test_scraping_parameters.py
+++ b/lambda/web-scraping/tests/config/test_scraping_parameters.py
@@ -12,8 +12,24 @@ class TestScrapingParameters:
             user_agent="Mozilla/5.0 test-agent",
         )
 
-        assert params.login_user_id == "user-id"
-        assert params.login_password == "password"
-        assert params.login_birthdate == "19800101"
+        assert params.login_user_id.get_secret_value() == "user-id"
+        assert params.login_password.get_secret_value() == "password"
+        assert params.login_birthdate.get_secret_value() == "19800101"
         assert params.start_url == "https://example.com/login"
         assert params.user_agent == "Mozilla/5.0 test-agent"
+
+    def test_repr__masks_sensitive_fields(self):
+        """repr() の出力に認証情報の平文が含まれない"""
+        params = ScrapingParameters(
+            login_user_id="secret-user-123",
+            login_password="secret-pass-456",
+            login_birthdate="19800101",
+            start_url="https://example.com/login",
+            user_agent="Mozilla/5.0 test-agent",
+        )
+
+        result = repr(params)
+
+        assert "secret-user-123" not in result
+        assert "secret-pass-456" not in result
+        assert "19800101" not in result


### PR DESCRIPTION
ScrapingParameters の login_user_id / login_password / login_birthdate を pydantic.SecretStr に変更し、
repr / model_dump 経由での平文露出を防ぐ。
SeleniumScraper._login の send_keys 呼び出しを
.get_secret_value() 経由に追従。

ref: CodeRabbit review on #153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **セキュリティ改善**
  * 認証情報（ユーザーID、パスワード、生年月日）の取り扱いを強化し、機密データの安全性を向上させました。これらの情報はデバッグ出力やログで平文として表示されなくなります。

* **テスト**
  * 認証情報のセキュアな取り扱いを検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->