### PR TITLE
テスト用 LINE API URL をダミーに変更

### DIFF
--- a/lambda/summary-notification/tests/infrastructure/test_line_notifier.py
+++ b/lambda/summary-notification/tests/infrastructure/test_line_notifier.py
@@ -3,7 +3,7 @@ import pytest
 from src.domain import NotificationFailed
 from src.infrastructure import LineNotifier
 
-LINE_API_URL = "https://api.line.me/v2/bot/message/push"
+LINE_API_URL = "http://test.invalid/line/messages"
 LINE_TOKEN = "test-token"
 
 


### PR DESCRIPTION
test_line_notifier.py の LINE_API_URL に本物の LINE Messaging API エンドポイントが書かれていたためダミー URL に差し替え、テストコードから
本番エンドポイント参照を排除する。requests_mock により実 API には
接続しないが、コードリーディング時の誤解とノイズを避ける。

Closes #124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * テスト環境の設定を改善しました。

このリリースには、エンドユーザーに対する目立った変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->