### PR TITLE
命名の一貫性を改善

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -62,7 +62,7 @@ Presentation → Application → Domain ← Infrastructure
 失敗は早期に検知し、ERROR ログを出力する。握りつぶさない。
 
 - スクレイピング失敗時: スクリーンショット/HTML を S3 の `errors/` に保存してから ERROR ログ出力
-- 通知失敗時: ERROR ログ出力 + Lambda リトライ（`NotificationFailed` 例外を raise）
+- 通知失敗時: ERROR ログ出力 + Lambda リトライ（`NotificationError` 例外を raise）
 
 ### 監視
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -90,8 +90,8 @@ CDK 初回ブートストラップ（初回のみ）: `cdk bootstrap aws://ACCOU
 | モジュール | 内容 |
 |---|---|
 | `domain/financial_asset.py` | `FinancialAsset` / `FinancialAssetHistory` / `AssetValuation` 等のドメインモデル |
-| `domain/financial_asset_repository.py` | `IFinancialAssetRepository`（読み書き両用の基底 IF） |
-| `domain/exceptions.py` | `AssetRecordError` 基底例外 |
+| `domain/financial_asset_repository_interface.py` | `IFinancialAssetRepository`（読み書き両用の基底 IF） |
+| `domain/exceptions.py` | `AssetSaveError` 基底例外 |
 | `infrastructure/ssm_parameter.py` | SSM Parameter Store クライアント |
 | `config/base_settings.py` | Logger・BaseSettings（aws-lambda-powertools ベース） |
 

--- a/lambda/asset-collection/src/application/__init__.py
+++ b/lambda/asset-collection/src/application/__init__.py
@@ -1,15 +1,15 @@
-from .asset_fetcher_interface import ExtractFailed, IAssetFetcher, LoginFailed, NavigatePageFailed
-from .collect_asset_interface import ICollectDailyAssetUseCase
-from .collect_asset_usecase import CollectAssetDailyUseCase
+from .asset_fetcher_interface import ExtractError, IAssetFetcher, LoginError, NavigatePageError
+from .collect_asset_daily_interface import ICollectAssetDailyUseCase
+from .collect_asset_daily_usecase import CollectAssetDailyUseCase
 from .error_artifact_repository_interface import ErrorArtifactUploadError, IErrorArtifactRepository
 
 __all__ = [
     "CollectAssetDailyUseCase",
     "ErrorArtifactUploadError",
-    "ExtractFailed",
+    "ExtractError",
     "IAssetFetcher",
-    "ICollectDailyAssetUseCase",
+    "ICollectAssetDailyUseCase",
     "IErrorArtifactRepository",
-    "LoginFailed",
-    "NavigatePageFailed",
+    "LoginError",
+    "NavigatePageError",
 ]

--- a/lambda/asset-collection/src/application/asset_fetcher_interface.py
+++ b/lambda/asset-collection/src/application/asset_fetcher_interface.py
@@ -35,13 +35,13 @@ class IAssetFetcher(ABC):
         """/tmp/ に保存したページソース（HTML）のファイルパスを返す"""
 
 
-class LoginFailed(Exception):
+class LoginError(Exception):
     pass
 
 
-class NavigatePageFailed(Exception):
+class NavigatePageError(Exception):
     pass
 
 
-class ExtractFailed(Exception):
+class ExtractError(Exception):
     pass

--- a/lambda/asset-collection/src/application/collect_asset_daily_interface.py
+++ b/lambda/asset-collection/src/application/collect_asset_daily_interface.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 
 
-class ICollectDailyAssetUseCase(ABC):
+class ICollectAssetDailyUseCase(ABC):
     @abstractmethod
     def execute(self) -> None:
         """資産運用状況ページからアセット情報を収集し、データストアへ保存する"""

--- a/lambda/asset-collection/src/application/collect_asset_daily_usecase.py
+++ b/lambda/asset-collection/src/application/collect_asset_daily_usecase.py
@@ -4,14 +4,14 @@ from pathlib import Path
 from src.config import AssetFetchConfig, get_logger
 from src.domain import IFinancialAssetRepository
 
-from .asset_fetcher_interface import ExtractFailed, IAssetFetcher, LoginFailed, NavigatePageFailed
-from .collect_asset_interface import ICollectDailyAssetUseCase
+from .asset_fetcher_interface import ExtractError, IAssetFetcher, LoginError, NavigatePageError
+from .collect_asset_daily_interface import ICollectAssetDailyUseCase
 from .error_artifact_repository_interface import IErrorArtifactRepository
 
 logger = get_logger()
 
 
-class CollectAssetDailyUseCase(ICollectDailyAssetUseCase):
+class CollectAssetDailyUseCase(ICollectAssetDailyUseCase):
     def __init__(
         self,
         fetcher: IAssetFetcher,
@@ -33,21 +33,21 @@ class CollectAssetDailyUseCase(ICollectDailyAssetUseCase):
             except Exception as e:
                 logger.error("ログイン処理に失敗しました。", extra={"error": str(e)})
                 self._store_artifact(self.fetcher.capture_screenshot())
-                raise LoginFailed() from e
+                raise LoginError() from e
 
             try:
                 self.fetcher.navigate_to_asset_page()
             except Exception as e:
                 logger.error("資産評価額照会ページへの遷移に失敗しました。", extra={"error": str(e)})
                 self._store_artifact(self.fetcher.capture_screenshot())
-                raise NavigatePageFailed() from e
+                raise NavigatePageError() from e
 
             try:
                 daily_assets = self.fetcher.extract()
             except Exception as e:
                 logger.error("資産情報の抽出に失敗しました。", extra={"error": str(e)})
                 self._store_artifact(self.fetcher.get_page_source())
-                raise ExtractFailed() from e
+                raise ExtractError() from e
 
             self.repository.save_daily(daily_assets)
         finally:

--- a/lambda/asset-collection/src/domain/__init__.py
+++ b/lambda/asset-collection/src/domain/__init__.py
@@ -1,4 +1,4 @@
-from shared.domain.exceptions import AssetRecordError
+from shared.domain.exceptions import AssetSaveError
 from shared.domain.financial_asset import (
     AssetValuation,
     CumulativeContributions,
@@ -6,7 +6,7 @@ from shared.domain.financial_asset import (
     FinancialAssetHistory,
     GainsOrLosses,
 )
-from shared.domain.financial_asset_repository import IFinancialAssetRepository
+from shared.domain.financial_asset_repository_interface import IFinancialAssetRepository
 
 __all__ = [
     # Models
@@ -18,5 +18,5 @@ __all__ = [
     # Interfaces
     "IFinancialAssetRepository",
     # Exceptions
-    "AssetRecordError",
+    "AssetSaveError",
 ]

--- a/lambda/asset-collection/src/infrastructure/google_sheet_financial_asset_repository.py
+++ b/lambda/asset-collection/src/infrastructure/google_sheet_financial_asset_repository.py
@@ -3,7 +3,7 @@ from google.oauth2.service_account import Credentials
 from gspread.utils import ValueInputOption
 
 from src.config import get_logger
-from src.domain import AssetRecordError, FinancialAssetHistory, IFinancialAssetRepository
+from src.domain import AssetSaveError, FinancialAssetHistory, IFinancialAssetRepository
 
 logger = get_logger()
 
@@ -23,24 +23,25 @@ class GoogleSheetFinancialAssetRepository(IFinancialAssetRepository):
         """1日分の金融資産履歴をスプレッドシートに保存する
 
         Raises:
-            AssetRecordError: レコード保存失敗時
+            AssetSaveError: 保存失敗時
         """
         if not daily_assets.assets:
             return
 
         try:
+            # TODO: 複数日付チェックは FinancialAssetHistory のメソッドに移動する
             base_dates = {asset.base_date for asset in daily_assets.assets}
             if len(base_dates) > 1:
-                raise AssetRecordError(f"save_daily に複数日付の資産が含まれています: {base_dates}")
+                raise AssetSaveError(f"save_daily に複数日付の資産が含まれています: {base_dates}")
 
             target_date = str(daily_assets.assets[0].base_date)
             self._delete_existing_rows(target_date)
             self._append_assets(daily_assets)
             logger.info("金融資産履歴を保存しました", extra={"date": target_date, "count": len(daily_assets.assets)})
-        except AssetRecordError:
+        except AssetSaveError:
             raise
         except Exception as e:
-            raise AssetRecordError(f"金融資産履歴の保存に失敗しました: {e}") from e
+            raise AssetSaveError(f"金融資産履歴の保存に失敗しました: {e}") from e
 
     def _delete_existing_rows(self, target_date: str) -> None:
         """対象日付の既存行を削除する"""

--- a/lambda/asset-collection/src/presentation/asset_collection_handler.py
+++ b/lambda/asset-collection/src/presentation/asset_collection_handler.py
@@ -1,10 +1,10 @@
 from typing import Literal
 
-from src.application import ICollectDailyAssetUseCase
+from src.application import ICollectAssetDailyUseCase
 
 
 class Main:
-    def __init__(self, usecase: ICollectDailyAssetUseCase):
+    def __init__(self, usecase: ICollectAssetDailyUseCase):
         self.usecase = usecase
 
     def run(self) -> Literal["Success"]:

--- a/lambda/asset-collection/tests/application/test_collect_asset_usecase.py
+++ b/lambda/asset-collection/tests/application/test_collect_asset_usecase.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from src.application import CollectAssetDailyUseCase, ExtractFailed, LoginFailed, NavigatePageFailed
+from src.application import CollectAssetDailyUseCase, ExtractError, LoginError, NavigatePageError
 from src.domain import (
     AssetValuation,
     CumulativeContributions,
@@ -66,9 +66,9 @@ def make_usecase(fetcher, repo=None, error_repo=None, config=None):
 
 def test_execute__all_steps_succeed__saves_assets(valid_history):
     """全ステップ成功時に save_daily が呼ばれる"""
-    from tests.fixtures.mocks import MockFinancialAssetRepository, MockSeleniumAssetFetcher
+    from tests.fixtures.mocks import MockAssetFetcher, MockFinancialAssetRepository
 
-    fetcher = MockSeleniumAssetFetcher(mock_history=valid_history)
+    fetcher = MockAssetFetcher(mock_history=valid_history)
     repo = MockFinancialAssetRepository()
     usecase = make_usecase(fetcher=fetcher, repo=repo)
 
@@ -81,14 +81,14 @@ def test_execute__all_steps_succeed__saves_assets(valid_history):
 
 
 def test_execute__login_fails__stores_screenshot_and_raises():
-    """login 失敗時にスクリーンショット保存 + LoginFailed を raise する"""
-    from tests.fixtures.mocks import MockErrorArtifactRepository, MockSeleniumAssetFetcher
+    """login 失敗時にスクリーンショット保存 + LoginError を raise する"""
+    from tests.fixtures.mocks import MockAssetFetcher, MockErrorArtifactRepository
 
-    fetcher = MockSeleniumAssetFetcher(fail_at="login")
+    fetcher = MockAssetFetcher(fail_at="login")
     error_repo = MockErrorArtifactRepository()
     usecase = make_usecase(fetcher=fetcher, error_repo=error_repo)
 
-    with pytest.raises(LoginFailed):
+    with pytest.raises(LoginError):
         usecase.execute()
 
     assert len(error_repo.stored_keys) == 1
@@ -97,12 +97,12 @@ def test_execute__login_fails__stores_screenshot_and_raises():
 
 def test_execute__login_fails__calls_logout_and_close():
     """login 失敗時でも finally で logout / close が呼ばれる"""
-    from tests.fixtures.mocks import MockSeleniumAssetFetcher
+    from tests.fixtures.mocks import MockAssetFetcher
 
-    fetcher = MockSeleniumAssetFetcher(fail_at="login")
+    fetcher = MockAssetFetcher(fail_at="login")
     usecase = make_usecase(fetcher=fetcher)
 
-    with pytest.raises(LoginFailed):
+    with pytest.raises(LoginError):
         usecase.execute()
 
     assert fetcher.logout_called
@@ -110,14 +110,14 @@ def test_execute__login_fails__calls_logout_and_close():
 
 
 def test_execute__navigate_fails__stores_screenshot_and_raises():
-    """navigate 失敗時にスクリーンショット保存 + NavigatePageFailed を raise する"""
-    from tests.fixtures.mocks import MockErrorArtifactRepository, MockSeleniumAssetFetcher
+    """navigate 失敗時にスクリーンショット保存 + NavigatePageError を raise する"""
+    from tests.fixtures.mocks import MockAssetFetcher, MockErrorArtifactRepository
 
-    fetcher = MockSeleniumAssetFetcher(fail_at="navigate")
+    fetcher = MockAssetFetcher(fail_at="navigate")
     error_repo = MockErrorArtifactRepository()
     usecase = make_usecase(fetcher=fetcher, error_repo=error_repo)
 
-    with pytest.raises(NavigatePageFailed):
+    with pytest.raises(NavigatePageError):
         usecase.execute()
 
     assert len(error_repo.stored_keys) == 1
@@ -125,14 +125,14 @@ def test_execute__navigate_fails__stores_screenshot_and_raises():
 
 
 def test_execute__extract_fails__stores_page_source_and_raises():
-    """extract 失敗時にページソース保存 + ExtractFailed を raise する"""
-    from tests.fixtures.mocks import MockErrorArtifactRepository, MockSeleniumAssetFetcher
+    """extract 失敗時にページソース保存 + ExtractError を raise する"""
+    from tests.fixtures.mocks import MockAssetFetcher, MockErrorArtifactRepository
 
-    fetcher = MockSeleniumAssetFetcher(fail_at="extract")
+    fetcher = MockAssetFetcher(fail_at="extract")
     error_repo = MockErrorArtifactRepository()
     usecase = make_usecase(fetcher=fetcher, error_repo=error_repo)
 
-    with pytest.raises(ExtractFailed):
+    with pytest.raises(ExtractError):
         usecase.execute()
 
     assert len(error_repo.stored_keys) == 1
@@ -141,22 +141,22 @@ def test_execute__extract_fails__stores_page_source_and_raises():
 
 def test_execute__artifact_store_fails__does_not_raise_artifact_error():
     """エラーアーティファクト保存失敗時は警告ログのみで例外を握りつぶす"""
-    from tests.fixtures.mocks import MockErrorArtifactRepository, MockSeleniumAssetFetcher
+    from tests.fixtures.mocks import MockAssetFetcher, MockErrorArtifactRepository
 
-    fetcher = MockSeleniumAssetFetcher(fail_at="login")
+    fetcher = MockAssetFetcher(fail_at="login")
     error_repo = MockErrorArtifactRepository(should_fail=True)
     usecase = make_usecase(fetcher=fetcher, error_repo=error_repo)
 
-    # LoginFailed は raise されるが ErrorArtifactUploadError は伝播しない
-    with pytest.raises(LoginFailed):
+    # LoginError は raise されるが ErrorArtifactUploadError は伝播しない
+    with pytest.raises(LoginError):
         usecase.execute()
 
 
 def test_execute__success__calls_logout_and_close(valid_history):
     """成功時も finally で logout / close が呼ばれる"""
-    from tests.fixtures.mocks import MockSeleniumAssetFetcher
+    from tests.fixtures.mocks import MockAssetFetcher
 
-    fetcher = MockSeleniumAssetFetcher(mock_history=valid_history)
+    fetcher = MockAssetFetcher(mock_history=valid_history)
     usecase = make_usecase(fetcher=fetcher)
 
     usecase.execute()

--- a/lambda/asset-collection/tests/fixtures/mocks/__init__.py
+++ b/lambda/asset-collection/tests/fixtures/mocks/__init__.py
@@ -1,5 +1,5 @@
+from tests.fixtures.mocks.mock_asset_fetcher import MockAssetFetcher
 from tests.fixtures.mocks.mock_error_artifact_repository import MockErrorArtifactRepository
 from tests.fixtures.mocks.mock_financial_asset_repository import MockFinancialAssetRepository
-from tests.fixtures.mocks.mock_selenium_asset_fetcher import MockSeleniumAssetFetcher
 
-__all__ = ["MockErrorArtifactRepository", "MockFinancialAssetRepository", "MockSeleniumAssetFetcher"]
+__all__ = ["MockAssetFetcher", "MockErrorArtifactRepository", "MockFinancialAssetRepository"]

--- a/lambda/asset-collection/tests/fixtures/mocks/mock_asset_fetcher.py
+++ b/lambda/asset-collection/tests/fixtures/mocks/mock_asset_fetcher.py
@@ -2,8 +2,8 @@ from src.application import IAssetFetcher
 from src.domain import FinancialAssetHistory
 
 
-class MockSeleniumAssetFetcher(IAssetFetcher):
-    """Selenium WebDriver の Mock 実装（テスト用）
+class MockAssetFetcher(IAssetFetcher):
+    """IAssetFetcher の Mock 実装（テスト用）
 
     実際にブラウザを起動せず、事前に用意した金融資産履歴を返す Mock オブジェクト。
     fail_at を指定することで任意のステップで失敗させることができる。

--- a/lambda/shared/src/shared/domain/exceptions.py
+++ b/lambda/shared/src/shared/domain/exceptions.py
@@ -1,2 +1,2 @@
-class AssetRecordError(Exception):
-    """資産レコード操作の例外"""
+class AssetSaveError(Exception):
+    """リポジトリへの保存失敗例外"""

--- a/lambda/shared/src/shared/domain/financial_asset_repository_interface.py
+++ b/lambda/shared/src/shared/domain/financial_asset_repository_interface.py
@@ -14,7 +14,7 @@ class IFinancialAssetRepository(ABC):
         既存レコードを削除してから保存する（upsert セマンティクス）。
 
         Raises:
-            AssetRecordError: レコード保存失敗時
+            AssetSaveError: 保存失敗時
         """
 
     @abstractmethod

--- a/lambda/summary-notification/src/application/__init__.py
+++ b/lambda/summary-notification/src/application/__init__.py
@@ -1,10 +1,10 @@
-from .notifier_interface import INotifier, NotificationFailed
+from .notifier_interface import INotifier, NotificationError
 from .notify_weekly_summary_interface import INotifyWeeklySummaryUseCase
 from .notify_weekly_summary_usecase import NotifyWeeklySummaryUseCase
 
 __all__ = [
     "INotifier",
     "INotifyWeeklySummaryUseCase",
-    "NotificationFailed",
+    "NotificationError",
     "NotifyWeeklySummaryUseCase",
 ]

--- a/lambda/summary-notification/src/application/notifier_interface.py
+++ b/lambda/summary-notification/src/application/notifier_interface.py
@@ -13,12 +13,12 @@ class INotifier(ABC):
             messages: 通知メッセージリスト
 
         Raises:
-            NotificationFailed: 通知送信失敗時
+            NotificationError: 通知送信失敗時
         """
         pass
 
 
-class NotificationFailed(Exception):
+class NotificationError(Exception):
     """通知送信エラー"""
 
     @classmethod
@@ -26,7 +26,7 @@ class NotificationFailed(Exception):
         """通知送信中にエラーが発生した場合の例外インスタンスを生成する名前付きコンストラクタ
 
         Returns:
-            NotificationFailed: 生成された例外インスタンス
+            NotificationError: 生成された例外インスタンス
         """
         return cls("通知送信中にエラーが発生しました")
 
@@ -35,6 +35,6 @@ class NotificationFailed(Exception):
         """通知送信前にエラーが発生した場合の例外インスタンスを生成する名前付きコンストラクタ
 
         Returns:
-            NotificationFailed: 生成された例外インスタンス
+            NotificationError: 生成された例外インスタンス
         """
         return cls("通知送信前にエラーが発生しました")

--- a/lambda/summary-notification/src/domain/__init__.py
+++ b/lambda/summary-notification/src/domain/__init__.py
@@ -6,11 +6,11 @@ from shared.domain.financial_asset import (
     GainsOrLosses,
     LatestPortfolioTotal,
 )
-from shared.domain.financial_asset_repository import IFinancialAssetRepository
+from shared.domain.financial_asset_repository_interface import IFinancialAssetRepository
 
 from .exceptions import (
-    AssetRetrievalFailed,
-    SummaryNotificationFailed,
+    AssetRetrievalError,
+    SummaryNotificationError,
 )
 
 __all__ = [
@@ -24,6 +24,6 @@ __all__ = [
     # Interfaces
     "IFinancialAssetRepository",
     # Exceptions
-    "AssetRetrievalFailed",
-    "SummaryNotificationFailed",
+    "AssetRetrievalError",
+    "SummaryNotificationError",
 ]

--- a/lambda/summary-notification/src/domain/exceptions.py
+++ b/lambda/summary-notification/src/domain/exceptions.py
@@ -1,14 +1,14 @@
 from typing import Self
 
 
-class SummaryNotificationFailed(Exception):
+class SummaryNotificationError(Exception):
     """サマリ通知機能のベース例外"""
 
     pass
 
 
 # TODO: Repositoryと同様のファイルに移動する
-class AssetRetrievalFailed(SummaryNotificationFailed):
+class AssetRetrievalError(SummaryNotificationError):
     """資産情報の取得エラー"""
 
     @classmethod
@@ -16,7 +16,7 @@ class AssetRetrievalFailed(SummaryNotificationFailed):
         """スプレッドシートに資産情報が存在しない場合の例外を生成
 
         Returns:
-            AssetRetrievalFailed: 生成された例外インスタンス
+            AssetRetrievalError: 生成された例外インスタンス
         """
         return cls("スプレッドシートに資産情報が見つかりません")
 
@@ -25,6 +25,6 @@ class AssetRetrievalFailed(SummaryNotificationFailed):
         """資産情報の取得中にエラーが発生した場合の例外インスタンスを生成する名前付きコンストラクタ
 
         Returns:
-            AssetRetrievalFailed: 生成された例外インスタンス
+            AssetRetrievalError: 生成された例外インスタンス
         """
         return cls("資産情報の取得中にエラーが発生しました")

--- a/lambda/summary-notification/src/infrastructure/google_sheet_financial_asset_repository.py
+++ b/lambda/summary-notification/src/infrastructure/google_sheet_financial_asset_repository.py
@@ -6,7 +6,7 @@ from gspread.utils import rowcol_to_a1
 
 from src.config import get_logger
 from src.domain import (
-    AssetRetrievalFailed,
+    AssetRetrievalError,
     AssetValuation,
     CumulativeContributions,
     FinancialAsset,
@@ -57,10 +57,10 @@ class GoogleSheetFinancialAssetRepository(IFinancialAssetRepository):
             history = self._batch_get_assets(headers, target_rows)
             logger.info("金融資産履歴を取得しました", extra={"days": days, "count": len(history.assets)})
             return history
-        except (AssetRetrievalFailed, ValueError):
+        except (AssetRetrievalError, ValueError):
             raise
         except Exception as e:
-            raise AssetRetrievalFailed.during_fetching() from e
+            raise AssetRetrievalError.during_fetching() from e
 
     def _batch_get_assets(self, headers: list[str], target_rows: list[int]) -> FinancialAssetHistory:
         if not target_rows:

--- a/lambda/summary-notification/src/infrastructure/line_notifier.py
+++ b/lambda/summary-notification/src/infrastructure/line_notifier.py
@@ -2,7 +2,7 @@ import json
 
 import requests
 
-from src.application import INotifier, NotificationFailed
+from src.application import INotifier, NotificationError
 from src.config import get_logger
 
 logger = get_logger()
@@ -35,7 +35,7 @@ class LineNotifier(INotifier):
             messages: 通知メッセージリスト
 
         Raises:
-            NotificationFailed: 通知送信失敗時
+            NotificationError: 通知送信失敗時
         """
         try:
             line_messages = self._convert_to_line_format(messages)
@@ -47,9 +47,9 @@ class LineNotifier(INotifier):
                 self._send_batch(batch)
 
         except requests.exceptions.RequestException as e:
-            raise NotificationFailed.during_request() from e
+            raise NotificationError.during_request() from e
         except Exception as e:
-            raise NotificationFailed.before_request() from e
+            raise NotificationError.before_request() from e
 
     def _send_batch(self, line_messages: list[dict]) -> None:
         """LINE API へメッセージを送信

--- a/lambda/summary-notification/tests/application/test_notify_weekly_summary_usecase.py
+++ b/lambda/summary-notification/tests/application/test_notify_weekly_summary_usecase.py
@@ -3,9 +3,9 @@ from datetime import date
 import pytest
 
 from src.application import INotifyWeeklySummaryUseCase, NotifyWeeklySummaryUseCase
-from src.application.notifier_interface import INotifier, NotificationFailed
+from src.application.notifier_interface import INotifier, NotificationError
 from src.domain import (
-    AssetRetrievalFailed,
+    AssetRetrievalError,
     AssetValuation,
     CumulativeContributions,
     FinancialAsset,
@@ -146,27 +146,27 @@ class TestNotifyWeeklySummaryUseCase:
         with pytest.raises(ValueError):
             usecase.execute()
 
-    def test_execute__repository_failure_raises_asset_retrieval_failed(self):
-        """リポジトリ失敗時は AssetRetrievalFailed を伝播させる"""
+    def test_execute__repository_failure_raises_asset_retrieval_error(self):
+        """リポジトリ失敗時は AssetRetrievalError を伝播させる"""
         repository = MockFinancialAssetRepository(should_fail=True)
         notifier = MockNotifier()
         usecase = NotifyWeeklySummaryUseCase(repository=repository, notifier=notifier)
 
-        with pytest.raises(AssetRetrievalFailed):
+        with pytest.raises(AssetRetrievalError):
             usecase.execute()
 
     def test_execute__notification_failure_propagates(self, sample_history: FinancialAssetHistory):
-        """notifier が NotificationFailed を送出した場合は伝播する"""
+        """notifier が NotificationError を送出した場合は伝播する"""
 
         class FailingNotifier(INotifier):
             def notify(self, messages: list[str]) -> None:
-                raise NotificationFailed.during_request()
+                raise NotificationError.during_request()
 
         repository = MockFinancialAssetRepository(history=sample_history)
         notifier = FailingNotifier()
         usecase = NotifyWeeklySummaryUseCase(repository=repository, notifier=notifier)
 
-        with pytest.raises(NotificationFailed):
+        with pytest.raises(NotificationError):
             usecase.execute()
 
     def test_execute__output_matches_expected_exactly(self, exact_match_history: FinancialAssetHistory):

--- a/lambda/summary-notification/tests/domain/test_domain_init_exports.py
+++ b/lambda/summary-notification/tests/domain/test_domain_init_exports.py
@@ -29,10 +29,10 @@ def test_domain_exports_financial_asset_repository_interface() -> None:
 
 def test_domain_exports_exceptions() -> None:
     """domain __init__ から例外クラスをインポートできる（既存動作の回帰確認）."""
-    from src.domain import AssetRetrievalFailed, SummaryNotificationFailed
+    from src.domain import AssetRetrievalError, SummaryNotificationError
 
-    assert AssetRetrievalFailed is not None
-    assert SummaryNotificationFailed is not None
+    assert AssetRetrievalError is not None
+    assert SummaryNotificationError is not None
 
 
 def test_domain_all_contains_expected_symbols() -> None:
@@ -47,8 +47,8 @@ def test_domain_all_contains_expected_symbols() -> None:
         "GainsOrLosses",
         "LatestPortfolioTotal",
         "IFinancialAssetRepository",
-        "AssetRetrievalFailed",
-        "SummaryNotificationFailed",
+        "AssetRetrievalError",
+        "SummaryNotificationError",
     }
 
     assert set(domain_module.__all__) == expected

--- a/lambda/summary-notification/tests/fixtures/mocks/mock_financial_asset_repository.py
+++ b/lambda/summary-notification/tests/fixtures/mocks/mock_financial_asset_repository.py
@@ -1,4 +1,4 @@
-from src.domain import AssetRetrievalFailed, FinancialAssetHistory, IFinancialAssetRepository
+from src.domain import AssetRetrievalError, FinancialAssetHistory, IFinancialAssetRepository
 
 
 class MockFinancialAssetRepository(IFinancialAssetRepository):
@@ -21,5 +21,5 @@ class MockFinancialAssetRepository(IFinancialAssetRepository):
         self.retrieve_called = True
         self.last_days_arg = days
         if self.should_fail:
-            raise AssetRetrievalFailed.during_fetching()
+            raise AssetRetrievalError.during_fetching()
         return self.history

--- a/lambda/summary-notification/tests/infrastructure/test_google_sheet_financial_asset_repository.py
+++ b/lambda/summary-notification/tests/infrastructure/test_google_sheet_financial_asset_repository.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from src.domain import (
-    AssetRetrievalFailed,
+    AssetRetrievalError,
     AssetValuation,
     CumulativeContributions,
     FinancialAsset,
@@ -98,13 +98,13 @@ class TestRetrieveFromWithDays:
         with pytest.raises(ValueError, match="days must be positive"):
             repository.retrieve_from_with_days(days=-1)
 
-    def test_retrieve_from_with_days__gspread_error_raises_asset_retrieval_failed(self, repository, mock_worksheet):
-        """gspread 例外発生時は AssetRetrievalFailed を送出する"""
+    def test_retrieve_from_with_days__gspread_error_raises_asset_retrieval_error(self, repository, mock_worksheet):
+        """gspread 例外発生時は AssetRetrievalError を送出する"""
         import gspread
 
         mock_worksheet.row_values.side_effect = gspread.exceptions.GSpreadException("API error")
 
-        with pytest.raises(AssetRetrievalFailed):
+        with pytest.raises(AssetRetrievalError):
             repository.retrieve_from_with_days(days=7)
 
     def test_retrieve_from_with_days__multiple_products_per_date(self, repository, mock_worksheet):

--- a/lambda/summary-notification/tests/infrastructure/test_line_notifier.py
+++ b/lambda/summary-notification/tests/infrastructure/test_line_notifier.py
@@ -1,6 +1,6 @@
 import pytest
 
-from src.application import NotificationFailed
+from src.application import NotificationError
 from src.infrastructure import LineNotifier
 
 LINE_API_URL = "http://test.invalid/line/messages"
@@ -30,14 +30,14 @@ class TestLineNotifier:
         assert sent_body["messages"][0]["type"] == "text"
         assert sent_body["messages"][0]["text"] == "テストメッセージ"
 
-    def test_notify__api_error_raises_notification_failed(self, notifier, requests_mock):
-        """API エラー時に NotificationFailed が発生する"""
+    def test_notify__api_error_raises_notification_error(self, notifier, requests_mock):
+        """API エラー時に NotificationError が発生する"""
         # given
         requests_mock.post(LINE_API_URL, status_code=500)
         messages = ["テスト"]
 
         # when, then
-        with pytest.raises(NotificationFailed):
+        with pytest.raises(NotificationError):
             notifier.notify(messages)
 
     def test_notify__authorization_header(self, notifier, requests_mock):


### PR DESCRIPTION
ファイル名・クラス名・例外名の命名をプロジェクト全体で統一する。

ファイル名・クラス名の改名:
- collect_asset_interface.py → collect_asset_daily_interface.py ICollectDailyAssetUseCase → ICollectAssetDailyUseCase（動詞+目的語+修飾語の順に統一）
- collect_asset_usecase.py → collect_asset_daily_usecase.py
- mock_selenium_asset_fetcher.py → mock_asset_fetcher.py MockSeleniumAssetFetcher → MockAssetFetcher（インターフェース名ベースに統一）
- financial_asset_repository.py → financial_asset_repository_interface.py 他の interface ファイルとサフィックスを統一

例外クラスの命名統一:
- XxxFailed → XxxError（Python 標準慣習に統一）
- AssetRecordError → AssetSaveError（CONTEXT.md のドメイン言語に準拠し、保存失敗の意図を明確化）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * 内部エラー命名規約を統一。エラークラスの名前付けを最新の標準に合わせました。
  * 一部の内部インターフェース名を整理しました。
  * テスト用モックコンポーネントを整理。

ユーザー向け機能に直接的な変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->