### PR TITLE
UseCase インターフェースを削除し具体型に変更

### DIFF
--- a/docs/adr/0004-no-usecase-interface.md
+++ b/docs/adr/0004-no-usecase-interface.md
@@ -1,0 +1,11 @@
+# UseCase レベルにインターフェースを設けない
+
+`ICollectAssetDailyUseCase` / `INotifyWeeklySummaryUseCase` は Application 層に定義されており、実装クラスも同じ Application 層に存在した。これは「インターフェースを消費者（高レベルモジュール）が所有する」という DIP の原則を満たさない。DIP として正しい置き場所は Presentation 層だが、単一実装かつ代替実装の予定がない現時点では過剰な抽象化になる。
+
+インターフェースを削除し、`Presentation.Main` は具体型（`CollectAssetDailyUseCase` / `NotifyWeeklySummaryUseCase`）を直接受け取るよう変更した。
+
+## Considered Options
+
+**却下: Application 層に UseCase インターフェースを残す（現状維持）** — 同一層内の ABC は DIP にならず、形式的な抽象化にとどまる。
+
+**却下: Presentation 層に UseCase インターフェースを移動する** — DIP としては正しいが、代替実装がない現状では YAGNI。代替実装が必要になった時点で導入すれば十分。

--- a/lambda/asset-collection/src/application/__init__.py
+++ b/lambda/asset-collection/src/application/__init__.py
@@ -1,5 +1,4 @@
 from .asset_fetcher_interface import ExtractError, IAssetFetcher, LoginError, NavigatePageError
-from .collect_asset_daily_interface import ICollectAssetDailyUseCase
 from .collect_asset_daily_usecase import CollectAssetDailyUseCase
 from .error_artifact_repository_interface import ErrorArtifactUploadError, IErrorArtifactRepository
 
@@ -8,7 +7,6 @@ __all__ = [
     "ErrorArtifactUploadError",
     "ExtractError",
     "IAssetFetcher",
-    "ICollectAssetDailyUseCase",
     "IErrorArtifactRepository",
     "LoginError",
     "NavigatePageError",

--- a/lambda/asset-collection/src/application/collect_asset_daily_interface.py
+++ b/lambda/asset-collection/src/application/collect_asset_daily_interface.py
@@ -1,7 +1,0 @@
-from abc import ABC, abstractmethod
-
-
-class ICollectAssetDailyUseCase(ABC):
-    @abstractmethod
-    def execute(self) -> None:
-        """資産運用状況ページからアセット情報を収集し、データストアへ保存する"""

--- a/lambda/asset-collection/src/application/collect_asset_daily_usecase.py
+++ b/lambda/asset-collection/src/application/collect_asset_daily_usecase.py
@@ -5,13 +5,12 @@ from src.config import AssetFetchConfig, get_logger
 from src.domain import IFinancialAssetRepository
 
 from .asset_fetcher_interface import ExtractError, IAssetFetcher, LoginError, NavigatePageError
-from .collect_asset_daily_interface import ICollectAssetDailyUseCase
 from .error_artifact_repository_interface import IErrorArtifactRepository
 
 logger = get_logger()
 
 
-class CollectAssetDailyUseCase(ICollectAssetDailyUseCase):
+class CollectAssetDailyUseCase:
     def __init__(
         self,
         fetcher: IAssetFetcher,

--- a/lambda/asset-collection/src/presentation/asset_collection_handler.py
+++ b/lambda/asset-collection/src/presentation/asset_collection_handler.py
@@ -1,10 +1,10 @@
 from typing import Literal
 
-from src.application import ICollectAssetDailyUseCase
+from src.application import CollectAssetDailyUseCase
 
 
 class Main:
-    def __init__(self, usecase: ICollectAssetDailyUseCase):
+    def __init__(self, usecase: CollectAssetDailyUseCase):
         self.usecase = usecase
 
     def run(self) -> Literal["Success"]:

--- a/lambda/summary-notification/src/application/__init__.py
+++ b/lambda/summary-notification/src/application/__init__.py
@@ -1,10 +1,8 @@
 from .notifier_interface import INotifier, NotificationError
-from .notify_weekly_summary_interface import INotifyWeeklySummaryUseCase
 from .notify_weekly_summary_usecase import NotifyWeeklySummaryUseCase
 
 __all__ = [
     "INotifier",
-    "INotifyWeeklySummaryUseCase",
     "NotificationError",
     "NotifyWeeklySummaryUseCase",
 ]

--- a/lambda/summary-notification/src/application/notify_weekly_summary_interface.py
+++ b/lambda/summary-notification/src/application/notify_weekly_summary_interface.py
@@ -1,7 +1,0 @@
-from abc import ABC, abstractmethod
-
-
-class INotifyWeeklySummaryUseCase(ABC):
-    @abstractmethod
-    def execute(self) -> None:
-        """直近1週間の資産運用サマリを整形し通知する"""

--- a/lambda/summary-notification/src/application/notify_weekly_summary_usecase.py
+++ b/lambda/summary-notification/src/application/notify_weekly_summary_usecase.py
@@ -4,7 +4,6 @@ from string import Template
 from src.domain import AssetValuation, FinancialAssetHistory, IFinancialAssetRepository, LatestPortfolioTotal
 
 from .notifier_interface import INotifier
-from .notify_weekly_summary_interface import INotifyWeeklySummaryUseCase
 
 _TEMPLATE = Template(
     "確定拠出年金 運用状況通知Bot\n"
@@ -19,7 +18,7 @@ _TEMPLATE = Template(
 _WEEKLY_HEADER = "資産評価額推移（直近1週間）\n"
 
 
-class NotifyWeeklySummaryUseCase(INotifyWeeklySummaryUseCase):
+class NotifyWeeklySummaryUseCase:
     DAYS = 7
 
     def __init__(self, repository: IFinancialAssetRepository, notifier: INotifier) -> None:

--- a/lambda/summary-notification/src/handler.py
+++ b/lambda/summary-notification/src/handler.py
@@ -1,6 +1,6 @@
 from aws_lambda_powertools.utilities.typing import LambdaContext
 
-from src.application import INotifier, INotifyWeeklySummaryUseCase, NotifyWeeklySummaryUseCase
+from src.application import INotifier, NotifyWeeklySummaryUseCase
 from src.config import EnvSettings, get_logger, get_settings
 from src.domain import IFinancialAssetRepository
 from src.infrastructure import (
@@ -35,7 +35,7 @@ def _build_notifier(settings: EnvSettings) -> INotifier:
     )
 
 
-def build_usecase() -> INotifyWeeklySummaryUseCase:
+def build_usecase() -> NotifyWeeklySummaryUseCase:
     settings = get_settings()
     return NotifyWeeklySummaryUseCase(
         repository=_build_financial_asset_repository(settings),

--- a/lambda/summary-notification/src/presentation/summary_notification_handler.py
+++ b/lambda/summary-notification/src/presentation/summary_notification_handler.py
@@ -1,10 +1,10 @@
 from typing import Literal
 
-from src.application import INotifyWeeklySummaryUseCase
+from src.application import NotifyWeeklySummaryUseCase
 
 
 class Main:
-    def __init__(self, usecase: INotifyWeeklySummaryUseCase) -> None:
+    def __init__(self, usecase: NotifyWeeklySummaryUseCase) -> None:
         self.usecase = usecase
 
     def run(self) -> Literal["Success"]:

--- a/lambda/summary-notification/tests/application/test_notify_weekly_summary_usecase.py
+++ b/lambda/summary-notification/tests/application/test_notify_weekly_summary_usecase.py
@@ -2,7 +2,7 @@ from datetime import date
 
 import pytest
 
-from src.application import INotifyWeeklySummaryUseCase, NotifyWeeklySummaryUseCase
+from src.application import NotifyWeeklySummaryUseCase
 from src.application.notifier_interface import INotifier, NotificationError
 from src.domain import (
     AssetRetrievalError,
@@ -233,17 +233,6 @@ class TestMain:
         message = notifier.messages_sent[0]
         assert "確定拠出年金 運用状況通知Bot" in message
         assert "1,200,000円" in message
-
-    def test_main__accepts_inotify_weekly_summary_usecase(self):
-        """Main の __init__ が INotifyWeeklySummaryUseCase を受け付ける"""
-        from src.presentation import Main
-
-        class StubUseCase(INotifyWeeklySummaryUseCase):
-            def execute(self) -> None:
-                pass
-
-        main = Main(usecase=StubUseCase())
-        assert isinstance(main, Main)
 
     def test_main__empty_history_raises_value_error(self):
         """空の資産履歴の場合 ValueError が伝播する"""


### PR DESCRIPTION
Application 層の ICollectAssetDailyUseCase / INotifyWeeklySummaryUseCase は 実装クラスと同一層に存在しており DIP として機能していなかった。
単一実装かつ代替予定もないため YAGNI で削除し、Presentation 層は
具体型を直接参照するよう変更した。設計判断を ADR 0004 に記録。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * 使用ケースレベルのインターフェース設計方針を正式化しました。

* **Refactor**
  * 資産収集および週次サマリー通知の実装を簡潔化しました。インターフェース抽象化層を廃止し、具体的な実装クラスを直接利用するよう変更することで、コード構造を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->