### PR TITLE
improve: Lambda handler の Output を Pydantic 型で表現

### DIFF
--- a/lambda/asset-collection/src/config/settings.py
+++ b/lambda/asset-collection/src/config/settings.py
@@ -26,4 +26,4 @@ def get_settings() -> EnvSettings:
     Returns:
         EnvSettings: 環境変数の設定
     """
-    return EnvSettings()  # ty: ignore[missing-argument] # pyright: ignore[reportCallIssue]
+    return EnvSettings()  # pyright: ignore[reportCallIssue]

--- a/lambda/asset-collection/src/handler.py
+++ b/lambda/asset-collection/src/handler.py
@@ -16,9 +16,9 @@ settings = get_settings()
 
 
 @logger.inject_lambda_context
-def handler(event: dict, context: LambdaContext) -> str | None:
+def handler(event: dict, context: LambdaContext) -> dict:
     """Lambda handler エントリーポイント"""
-    return Main(build_usecase()).run()
+    return Main(build_usecase()).run().model_dump()
 
 
 def build_usecase() -> CollectAssetDailyUseCase:

--- a/lambda/asset-collection/src/presentation/__init__.py
+++ b/lambda/asset-collection/src/presentation/__init__.py
@@ -1,3 +1,3 @@
-from .asset_collection_handler import Main
+from .asset_collection_handler import AssetCollectionResult, Main
 
-__all__ = ["Main"]
+__all__ = ["AssetCollectionResult", "Main"]

--- a/lambda/asset-collection/src/presentation/asset_collection_handler.py
+++ b/lambda/asset-collection/src/presentation/asset_collection_handler.py
@@ -1,12 +1,18 @@
 from typing import Literal
 
+from pydantic import BaseModel
+
 from src.application import CollectAssetDailyUseCase
+
+
+class AssetCollectionResult(BaseModel):
+    status: Literal["Success"]
 
 
 class Main:
     def __init__(self, usecase: CollectAssetDailyUseCase):
         self.usecase = usecase
 
-    def run(self) -> Literal["Success"]:
+    def run(self) -> AssetCollectionResult:
         self.usecase.execute()
-        return "Success"
+        return AssetCollectionResult(status="Success")

--- a/lambda/asset-collection/tests/presentation/test_asset_collection_handler.py
+++ b/lambda/asset-collection/tests/presentation/test_asset_collection_handler.py
@@ -1,0 +1,49 @@
+from datetime import date
+from unittest.mock import MagicMock
+
+from src.domain import (
+    AssetValuation,
+    CumulativeContributions,
+    FinancialAsset,
+    FinancialAssetHistory,
+    GainsOrLosses,
+)
+
+
+def _make_usecase():
+    from src.application import CollectAssetDailyUseCase
+    from tests.fixtures.mocks import (
+        MockAssetFetcher,
+        MockErrorArtifactRepository,
+        MockFinancialAssetRepository,
+    )
+
+    history = FinancialAssetHistory(
+        assets=[
+            FinancialAsset(
+                product_name="プロダクト_1",
+                base_date=date.today(),
+                cumulative_contributions=CumulativeContributions(value=100_000),
+                gains_or_losses=GainsOrLosses(value=11_111),
+                asset_valuation=AssetValuation(value=111_111),
+            ),
+        ]
+    )
+    config = MagicMock()
+    config.start_url = "http://example.com"
+    return CollectAssetDailyUseCase(
+        fetcher=MockAssetFetcher(mock_history=history),
+        repository=MockFinancialAssetRepository(),
+        error_repo=MockErrorArtifactRepository(),
+        config=config,
+    )
+
+
+def test_main__run_returns_success_result():
+    """Main.run() が status=Success の結果を返す"""
+    from src.presentation import AssetCollectionResult, Main
+
+    result = Main(_make_usecase()).run()
+
+    assert isinstance(result, AssetCollectionResult)
+    assert result.status == "Success"

--- a/lambda/summary-notification/src/config/settings.py
+++ b/lambda/summary-notification/src/config/settings.py
@@ -13,4 +13,4 @@ class EnvSettings(BaseEnvSettings):
 
 @lru_cache()
 def get_settings() -> EnvSettings:
-    return EnvSettings()  # ty: ignore[missing-argument] # pyright: ignore[reportCallIssue]
+    return EnvSettings()  # pyright: ignore[reportCallIssue]

--- a/lambda/summary-notification/src/handler.py
+++ b/lambda/summary-notification/src/handler.py
@@ -14,8 +14,8 @@ logger = get_logger()
 
 
 @logger.inject_lambda_context
-def handler(event: dict, context: LambdaContext) -> str | None:
-    return Main(build_usecase()).run()
+def handler(event: dict, context: LambdaContext) -> dict:
+    return Main(build_usecase()).run().model_dump()
 
 
 def _build_financial_asset_repository(settings: EnvSettings) -> IFinancialAssetRepository:

--- a/lambda/summary-notification/src/presentation/__init__.py
+++ b/lambda/summary-notification/src/presentation/__init__.py
@@ -1,3 +1,3 @@
-from .summary_notification_handler import Main
+from .summary_notification_handler import Main, SummaryNotificationResult
 
-__all__ = ["Main"]
+__all__ = ["Main", "SummaryNotificationResult"]

--- a/lambda/summary-notification/src/presentation/summary_notification_handler.py
+++ b/lambda/summary-notification/src/presentation/summary_notification_handler.py
@@ -1,12 +1,18 @@
 from typing import Literal
 
+from pydantic import BaseModel
+
 from src.application import NotifyWeeklySummaryUseCase
+
+
+class SummaryNotificationResult(BaseModel):
+    status: Literal["Success"]
 
 
 class Main:
     def __init__(self, usecase: NotifyWeeklySummaryUseCase) -> None:
         self.usecase = usecase
 
-    def run(self) -> Literal["Success"]:
+    def run(self) -> SummaryNotificationResult:
         self.usecase.execute()
-        return "Success"
+        return SummaryNotificationResult(status="Success")

--- a/lambda/summary-notification/tests/application/test_notify_weekly_summary_usecase.py
+++ b/lambda/summary-notification/tests/application/test_notify_weekly_summary_usecase.py
@@ -225,8 +225,9 @@ class TestMain:
         usecase = NotifyWeeklySummaryUseCase(repository=repository, notifier=notifier)
 
         main = Main(usecase=usecase)
-        main.run()
+        result = main.run()
 
+        assert result.status == "Success"
         assert repository.retrieve_called
         assert notifier.notify_called
         assert len(notifier.messages_sent) == 1


### PR DESCRIPTION
## 概要

両 Lambda（asset-collection / summary-notification）の handler の戻り値を、裸の文字列 `"Success"` から Pydantic で型表現した構造化 dict に変更しました。

## 変更内容

| 対象 | 変更 |
|------|------|
| presentation 層 | `AssetCollectionResult` / `SummaryNotificationResult`（`status: Literal["Success"]`）を `*_handler.py` 内（`Main` と同居）に定義。`Main.run()` がこの Result を返す |
| `handler.py` | 戻り値型を `dict` にし、`Main(...).run().model_dump()` でシリアライズ（dict 化は handler 側の責務） |
| `__init__.py` | 各 Result 型を re-export |
| テスト | summary-notification の既存 `test_main` に `result.status == "Success"` を追加。asset-collection に presentation テストを新設 |

## 設計判断

`/grill-with-docs` で論点を 1 つずつ詰めた結果:

- **Input 型は作らない**: event は EventBridge スケジュール起動で常に空。空モデルは [ADR 0004](docs/adr/0004-no-usecase-interface.md) が却下した「形式だけの抽象化」と同型のため見送り。
- **Output は `status: Literal["Success"]` の器のみ**: 件数・基準日等の拡充は `execute()` の戻り値設計を巻き込む別決定なので段階を分離。
- **型名は Lambda 固有**（`HandlerOutput` 共通化・shared 化は不採用）: 早すぎる共通化（YAGNI）を避け、各 presentation が独立して育てられるようにする。
- **ドキュメント変更なし**: I/O 契約型は実装詳細でドメイン用語ではないため CONTEXT.md 対象外。reversible で ADR 3 条件も満たさない。

## 検証

両 Lambda 全テスト・lint・format・型チェック・CDK スナップショットすべて green（pre-commit フックで確認済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * Lambda ハンドラのレスポンス形式を標準化し、文字列ベースから構造化された辞書形式に変更しました。

* **Tests**
  * ハンドラとユースケースの動作を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->