### PR TITLE
improve(asset-collection): プラン移行期間中のプラン選択ページ処理を追加

### DIFF
--- a/lambda/asset-collection/src/infrastructure/selenium_asset_fetcher.py
+++ b/lambda/asset-collection/src/infrastructure/selenium_asset_fetcher.py
@@ -79,6 +79,20 @@ class SeleniumAssetFetcher(IAssetFetcher):
         # ログアウトボタンがなければログイン失敗とする
         self.driver.find_element(By.LINK_TEXT, "ログアウト")
 
+        # TODO: プラン移行完了後に削除する
+        self._select_transferring_out_plan()
+
+    def _select_transferring_out_plan(self) -> None:
+        rows = self.driver.find_elements(By.CSS_SELECTOR, "table.inputTable tbody tr")
+        for row in rows:
+            status_cells = row.find_elements(By.CSS_SELECTOR, "td[data-lang='jp']")
+            for cell in status_cells:
+                if "転出処理中" in cell.text:
+                    row.find_element(By.CSS_SELECTOR, "input[type='radio']").click()
+                    self.driver.find_element(By.ID, "btnSubmit").click()
+                    return
+        raise ValueError("転出処理中のプランが見つかりませんでした。")
+
     def navigate_to_asset_page(self) -> None:
         link_asset_valuation = self.driver.find_element(By.ID, "mainMenu01")
         link_asset_valuation.click()

--- a/lambda/asset-collection/tests/infrastructure/test_selenium_asset_fetcher.py
+++ b/lambda/asset-collection/tests/infrastructure/test_selenium_asset_fetcher.py
@@ -44,6 +44,16 @@ def test_open_start_page__calls_driver_get():
 # ---------- login ----------
 
 
+def _setup_transferring_out_row(fetcher: SeleniumAssetFetcher) -> MagicMock:
+    """_select_transferring_out_plan 用: 転出処理中のセルを持つ行をモックに登録する"""
+    mock_cell = MagicMock()
+    mock_cell.text = "転出処理中"
+    mock_row = MagicMock()
+    mock_row.find_elements.return_value = [mock_cell]
+    fetcher.driver.find_elements.return_value = [mock_row]
+    return mock_row
+
+
 def test_login__calls_driver_operations():
     """login() が WebDriver の find_element / send_keys / submit を正しく呼ぶ"""
     fetcher = _make_fetcher()
@@ -51,10 +61,34 @@ def test_login__calls_driver_operations():
     config.login_user_id.get_secret_value.return_value = "user"
     config.login_password.get_secret_value.return_value = "pass"
     config.login_birthdate.get_secret_value.return_value = "19900101"
+    _setup_transferring_out_row(fetcher)
 
     fetcher.login(config)
 
     assert fetcher.driver.find_element.called
+
+
+def test_login__transferring_out_row_found__clicks_radio_and_submit():
+    """login() で転出処理中の行が見つかった場合、ラジオボタンと決定ボタンを押下する"""
+    fetcher = _make_fetcher()
+    config = MagicMock()
+    mock_row = _setup_transferring_out_row(fetcher)
+
+    fetcher.login(config)
+
+    mock_row.find_element.assert_called_once_with("css selector", "input[type='radio']")
+    mock_row.find_element.return_value.click.assert_called_once()
+    fetcher.driver.find_element.assert_any_call("id", "btnSubmit")
+
+
+def test_login__transferring_out_row_not_found__raises_value_error():
+    """login() で転出処理中の行が見つからない場合、ValueError を raise する"""
+    fetcher = _make_fetcher()
+    config = MagicMock()
+    fetcher.driver.find_elements.return_value = []
+
+    with pytest.raises(ValueError, match="転出処理中のプランが見つかりませんでした"):
+        fetcher.login(config)
 
 
 def test_login__selenium_fails__raises_raw_exception():


### PR DESCRIPTION
## Summary

- ログイン後に表示されるプラン選択ページで「転出処理中」のプランを自動選択し、決定ボタンを押下する処理を `login()` に追加
- プラン移行完了後に削除予定（`# TODO: プラン移行完了後に削除する` でマーク済み）
- `IAssetFetcher` インターフェースへの変更なし。`_select_transferring_out_plan()` を private メソッドとして `login()` に吸収

## Test plan

- [x] `test_login__transferring_out_row_found__clicks_radio_and_submit` — 転出処理中の行が見つかった場合にラジオボタンと決定ボタンが押下されることを確認
- [x] `test_login__transferring_out_row_not_found__raises_value_error` — 転出処理中の行が見つからない場合に `ValueError` が raise されることを確認
- [x] Docker Compose でのローカル動作確認済み（`"Success"` 返却・6商品の資産情報を取得・保存）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ログイン時に転出処理中のプラン状態を自動検出・確認する機能を追加しました。
  * 転出処理中のプランが見つからない場合は適切なエラーメッセージを表示します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->